### PR TITLE
Add more failing tests of rest element reassignment.

### DIFF
--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/actual.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/actual.js
@@ -44,3 +44,33 @@ var b = function (foo, baz, ...bar) {
 function x (...rest) {
   rest[0] = 0;
 }
+
+function swap (...rest) {
+  [rest[0], rest[1]] = [rest[1], rest[0]];
+}
+
+function forIn (...rest) {
+  for (rest[0] in this) {
+    foo(rest[0]);
+  }
+}
+
+function inc (...rest) {
+  ++rest[0];
+}
+
+function dec (...rest) {
+  --rest[0];
+}
+
+function del (...rest) {
+  delete rest[0];
+}
+
+function method (...rest) {
+  rest[0]();
+}
+
+function newExp (...rest) {
+  new rest[0]();
+}

--- a/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
+++ b/packages/babel-plugin-transform-es2015-parameters/test/fixtures/parameters/rest-member-expression-deoptimisation/expected.js
@@ -77,3 +77,21 @@ function x() {
 
   rest[0] = 0;
 }
+
+function swap() {
+  for (var _len9 = arguments.length, rest = Array(_len9), _key9 = 0; _key9 < _len9; _key9++) {
+    rest[_key9] = arguments[_key9];
+  }
+
+  [rest[0], rest[1]] = [rest[1], rest[0]];
+}
+
+function x() {
+  for (var _len10 = arguments.length, rest = Array(_len10), _key10 = 0; _key10 < _len10; _key10++) {
+    rest[_key10] = arguments[_key10];
+  }
+
+  for (rest[0] in this) {
+    foo(rest[0]);
+  }
+}


### PR DESCRIPTION
This is a pull request onto your pull request https://github.com/babel/babel/pull/3249. If you merge this PR, that PR should be automatically updated. Fingers crossed!

I expect the new tests to fail, because they contain additional examples of member expressions that can't be replaced with conditional expressions.
